### PR TITLE
✅ test	장소를 찾는 로직에서 에러 발생을 확인하는 로그

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -261,31 +261,42 @@ public class ScheduleCommandService {
 
     @Transactional // Transactional 내에서 수정이 되어야 자동 변경 감지된다.
     public void createDepartLocation(Long scheduleId, CreateDepartLocationRequest request, String userId) throws JsonProcessingException {
-
+        log.info("elkTest1");
         Optional<Schedule> schedule = getSchedule(scheduleId);
-
+        log.info("elkTest2");
         // 출발장소 추가될때마다 매번 다른 중간장소가 나와야함. 기존의 중간장소는 모두 삭제
         metroTransferCommandRepository.deleteByScheduleId(scheduleId);
+        log.info("elkTest4");
         locationCommandRepository.deleteLocation(scheduleId);
+        log.info("elkTest5");
 
         ScheduleMember scheduleMember = getScheduleMember(scheduleId, userId);
+        log.info("elkTest6");
         Optional<Metro> metro = getMetro(request.getDepartLocationName());
+        log.info("elkTest7");
         setDepartLocation(request, metro, scheduleMember);
+        log.info("elkTest8");
 
         List<ScheduleMember> scheduleLocations = scheduleMemberQueryRepository.findByScheduleId(scheduleId);
+        log.info("elkTest9");
 
         // 출발장소들을 이용하여 중간장소 계산
         Double middleLatitude = getLatitude(scheduleLocations);
+        log.info("elkTest10");
         Double middleLongitude = getLongitude(scheduleLocations);
-
+        log.info("elkTest11");
         // 3개의 지하철역 정보를 가져오기
         List<JsonNode> subwayStation = findNearestStations(middleLatitude, middleLongitude);
+        log.info("elkTest12");
 
         // 중간 지하철역 후보 저장
         saveMiddleLocation(subwayStation, schedule);
+        log.info("elkTest13");
 
         em.flush();  // DB 반영
+        log.info("elkTest14");
         em.clear();  // 영속성 컨텍스트 초기화
+        log.info("elkTest15");
     }
 
     private void saveMiddleLocation(List<JsonNode> subwayStation, Optional<Schedule> schedule) {


### PR DESCRIPTION
api.ittaeok.uk/api/v1/schedules/create-depart-location/{scheduleId} 에 대해 정의하지 않은 500에러가 발생하여 해당 비즈니스 로직에 각 명령어 줄마다 확인성 log 추가

!! Aggignees , Label 붙여주세요!! <br>
!! Add a title 작성 규칙 :  -- 했습니다. -- 입니다. (X) 로그인 기능 구현했습니다. (x)  ->  로그인 기능 구현 완료 (O)

## ✅ 관련 이슈
- close #이슈번호

## 🛠️ 작업 내용
- 작업한 내용을 항목별로 간결하게 작성합니다.
- 예: 로그인 API 예외 처리 로직 추가
- 예: 중간 장소 투표 기능 구현

## 📸 스크린샷 (선택)
- API 응답 예시, 테스트 결과, 로그, DB 변경 사항 등 첨부할 수 있는 자료가 있다면 포함해주세요.

## 🧩 기타 참고사항
- 논의가 필요한 부분, 참고 링크, 특이사항 등
- 예: `X 기능`은 다음 PR에서 작업 예정입니다.
